### PR TITLE
Add checks around routing file requiring and calling

### DIFF
--- a/example/doesNotExportAFunction.js
+++ b/example/doesNotExportAFunction.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// This is an example of an INVALID router, as it doesn't export a function.
+
+exports.router = {};

--- a/example/notARoutingFile.dummy
+++ b/example/notARoutingFile.dummy
@@ -1,0 +1,1 @@
+I'll trip up Routemaster if it doesn't wrap my require in a try catch

--- a/routemaster.js
+++ b/routemaster.js
@@ -27,7 +27,15 @@ function getRoutingFiles(directory){
 
 function buildRouter(masterRouter, routingFile){
     var router = new Router();
-    require(routingFile)(router);
+    var routingFn;
+
+    try{
+        routingFn = require(routingFile);
+    } catch(e){}
+
+    if(typeof routingFn === 'function'){
+        routingFn(router);
+    }
 
     masterRouter.use(router);
     return masterRouter;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
---require expectations
 --timeout 10000
 --reporter spec
 --recursive


### PR DESCRIPTION
Got a small PR @BrandwatchLtd/vizia-admins 

This adds two checks before a routing file is executed:

* Check that the file required is actually a type of file Node understands (the try catch).
* Check that the file required is a `function` (the `typeof` check).

I've added some dummy files to `/examples` that the test suite reads when running. I've not needed to actually modify the tests because with the additional files, the suite completely crashes without the new code!