### PR TITLE
Alter Routemaster to accept an already instantiated express.Router.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ That's about it, PRs accepted.
 | option | required | description |
 | ------ | -------- | ----------- |
 | directory | yes | A directory containing modules with routes. May also contain subdirectories with routes modules and so forth. |
-| Router | yes | Use `express.Router` here. This allows Routemaster to be agnostic to express version. |
+| Router | yes* | Use `express.Router` here. This allows Routemaster to be agnostic to express version. |
+| router | no | Instead of the `Router` option, you _can_ pass an already instantiated `express.Router`. Useful for when you need to apply stuff to the Router before any routes are added. |
 | errorHandler | no | When given, errors thrown when attempting to require a routes module will be passed to this function. Useful for logging. When not given, errors are ignored. |
+
+_* If a router is passed, Router is not required._
 
 [router]: http://expressjs.com/4x/api.html#router
 [express]: http://expressjs.com/

--- a/routemaster.js
+++ b/routemaster.js
@@ -34,9 +34,14 @@ function appendToRouter(router, routingFile) {
 
 module.exports = function routemaster(opts){
     var options = opts || {};
+    var router;
 
-    if(!options.Router){
-        throw new Error('Routemaster requires express.Router as its Router option');
+    if(options.router){
+        router = options.router;
+    }else if(options.Router){
+        router = new options.Router();
+    }else{
+        throw new Error('Routemaster requires a Router constructor or a router option');
     }
 
     if(!options.directory){
@@ -45,13 +50,12 @@ module.exports = function routemaster(opts){
 
     var errorHandler = options.errorHandler || function(){};
     var routingFiles = getRoutingFiles(options.directory);
-    var router = new options.Router();
 
     for (var i = 0, len = routingFiles.length; i < len; i++) {
         try {
             appendToRouter(router, routingFiles[i]);
         } catch (e) {
-            errorHandler(e);
+            errorHandler(e, 'Could not append routing file ' + routingFiles[i]);
         }
     }
 

--- a/test/routemasterSpec.js
+++ b/test/routemasterSpec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var path = require('path');
 var express = require('express');
 var routemaster = require('../routemaster');
 
@@ -14,55 +15,106 @@ function isExpressRouter(router){
 describe('routemaster', function(){
     var router;
 
-    before(function(){
-        router = routemaster({
-            directory: '../example',
-            Router: express.Router
+    describe('when passed a Router instead of a router', function(){
+        before(function(){
+            router = routemaster({
+                directory: '../example',
+                Router: express.Router
+            });
+        });
+
+        it('throws if the express.Router option isn\'t passed', function(){
+            assert.throws(routemaster, /Routemaster requires a Router constructor or a router option/);
+        });
+
+        it('throws if the directory option isn\'t passed', function(){
+            assert.throws(function(){
+                routemaster({ Router: express.Router });
+            }, /Routemaster require a directory option/);
+        });
+
+        it('returns an Express Router', function(){
+            assert.strictEqual(isExpressRouter(router), true);
+        });
+
+        describe('the routing file ../example/routingFile', function(){
+            it('is part of the router', function(done){
+                router.handle({url: '/', method: 'GET'}, { end: done });
+            });
+        });
+
+        describe('the routing file ../example/subDirectory/routingFile', function(){
+            it('is part of the router', function(done){
+                router.handle({url: '/subdir', method: 'GET'}, { end: done });
+            });
         });
     });
 
-    it('throws if the express.Router option isn\'t passed', function(){
-        assert.throws(routemaster, /Routemaster requires express.Router as its Router option/);
-    });
+    describe('when passed a router instead of a Router', function(){
+        var newRouter;
 
-    it('throws if the directory option isn\'t passed', function(){
-        assert.throws(function(){
-            routemaster({ Router: express.Router });
-        }, /Routemaster require a directory option/);
-    });
+        before(function(){
+            newRouter = new express.Router();
 
-    it('returns an Express Router', function(){
-        assert.strictEqual(isExpressRouter(router), true);
-    });
-
-    describe('the routing file ../example/routingFile', function(){
-        it('should be part of the router', function(done){
-            router.handle({url: '/', method: 'GET'}, { end: done });
+            router = routemaster({
+                directory: '../example',
+                router: newRouter
+            });
         });
-    });
 
-    describe('the routing file ../example/subDirectory/routingFile', function(){
-        it('should be part of the router', function(done){
-            router.handle({url: '/subdir', method: 'GET'}, { end: done });
+        it('throws if the directory option isn\'t passed', function(){
+            assert.throws(function(){
+                routemaster({ router: newRouter });
+            }, /Routemaster require a directory option/);
+        });
+
+        it('returns the passed router', function(){
+            assert.strictEqual(router, newRouter);
+        });
+
+        describe('the routing file ../example/routingFile', function(){
+            it('is part of the router', function(done){
+                router.handle({url: '/', method: 'GET'}, { end: done });
+            });
+        });
+
+        describe('the routing file ../example/subDirectory/routingFile', function(){
+            it('is part of the router', function(done){
+                router.handle({url: '/subdir', method: 'GET'}, { end: done });
+            });
         });
     });
 
     describe('errorHandler', function(){
-        var errors = [];
+        var errors;
+        var descriptions;
 
         before(function(){
+            errors = [];
+            descriptions = [];
+
             router = routemaster({
                 directory: '../example',
                 Router: express.Router,
-                errorHandler: function(e){
+                errorHandler: function(e, desc){
                     errors.push(e);
+                    descriptions.push(desc);
                 }
             });
         });
 
-        it('is passed errors when attempting to require routing modules', function(){
-            assert.equal(errors.length, 1);
-            assert.ok(errors[0] instanceof SyntaxError);
+        describe('when requiring a routing module fails', function(){
+            it('is passed an error', function(){
+                assert.equal(errors.length, 1);
+                assert.ok(errors[0] instanceof SyntaxError);
+            });
+
+            it('is passed a description', function(){
+                var filePath = path.resolve(__dirname, '../example/notARoutingFile.dummy');
+
+                assert.equal(descriptions.length, 1);
+                assert.strictEqual(descriptions[0], 'Could not append routing file ' + filePath);
+            });
         });
     });
 });


### PR DESCRIPTION
Hey @BrandwatchLtd/vizia-dev 

This PR alters Routemaster to accept an already instantiated `express.Router` instead of just wanting the constructor. The Router constructor option is a bit of a holdover from when a fresh router was used for each routing file, now one isn't I'll probably just deprecate it at some point.

I need this functionality for adding rules that I want applied to _every_ route in the router. Such rules need to be added before any routes are added.

I've also added a description to the error function arguments, as the stack by itself doesn't necessarily make it immediately obvious where the error has come from.

I haven't made use of any new language features in this PR as I don't see the point in kicking old Node users to the curb over what is quite a trivial module anyway. Though I'll definitely revisit this once more time has passed.
